### PR TITLE
UX: Make the header highlight darkmode-friendly

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,7 +1,5 @@
-@import "common/foundation/variables";
-
 body.suspicious-post-detected {
   .d-header {
-    background-color: $danger-low;
+    background-color: var(--danger-low);
   }
 }


### PR DESCRIPTION
No more "white on semi-white"