### PR TITLE
FIX: Don't fail if `.cooked` is missing

### DIFF
--- a/javascripts/discourse/initializers/post-height-detective.js
+++ b/javascripts/discourse/initializers/post-height-detective.js
@@ -47,6 +47,11 @@ export default {
           const topicId = this.get("posts.posts.firstObject.topic.id");
           const postLink = `${window.location.protocol}//${window.location.hostname}/t/${topicId}/${postNumber}`;
           const postElement = post.querySelector(".cooked");
+
+          if (!postElement) {
+            return;
+          }
+
           const renderedHeight = postElement.getBoundingClientRect().height;
           const oldHeight = this.recordedHeights.get(post);
 


### PR DESCRIPTION
Happens when transitioning between topics. (because reasons 😄)