### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/javascripts/discourse/initializers/post-height-detective.js
+++ b/javascripts/discourse/initializers/post-height-detective.js
@@ -9,73 +9,79 @@ export default {
 
   initialize() {
     withPluginApi("1.1.0", (api) => {
-      api.modifyClass("component:scrolling-post-stream", {
-        pluginId: "post-height-detective",
-
-        init() {
-          this._super(...arguments);
-          this.recordedHeights = new WeakMap();
-          this.recordedHtml = new WeakMap();
-          this.resizeObserver = new ResizeObserver(this.resizeObserverCallback);
-        },
-
-        afterRender() {
-          // Do this super quick whenever rerendering happens,
-          // otherwise we might miss something
-          this.trackElements();
-        },
-
-        trackElements() {
-          this.element
-            .querySelectorAll("article[data-post-id]")
-            .forEach((e) => this.resizeObserver.observe(e));
-        },
-
-        @bind
-        resizeObserverCallback(resizeObserverEntries) {
-          if (this.isDestroying || this.isDestroyed) {
-            return;
-          }
-
-          for (const entry of resizeObserverEntries) {
-            this.trackHeight(entry.target);
-          }
-        },
-
-        trackHeight(post) {
-          const postNumber = post.id.split("_")[1];
-          const topicId = this.get("posts.posts.firstObject.topic.id");
-          const postLink = `${window.location.protocol}//${window.location.hostname}/t/${topicId}/${postNumber}`;
-          const postElement = post.querySelector(".cooked");
-
-          if (!postElement) {
-            return;
-          }
-
-          const renderedHeight = postElement.getBoundingClientRect().height;
-          const oldHeight = this.recordedHeights.get(post);
-
-          if (oldHeight && renderedHeight !== oldHeight) {
-            console.error(
-              `🕵 Height of ${postLink} has changed after initial render. Was ${oldHeight}, now ${renderedHeight}`
-            );
-
-            const recordedHtml = this.recordedHtml.get(post);
-            if (recordedHtml === postElement.outerHTML) {
-              console.log("No HTML change, check CSS");
-            } else {
-              console.log(
-                `Previous HTML:\n\n${recordedHtml}\n\nCurrent HTML:\n\n${postElement.outerHTML}`
+      api.modifyClass(
+        "component:scrolling-post-stream",
+        (Superclass) =>
+          class extends Superclass {
+            init() {
+              super.init(...arguments);
+              this.recordedHeights = new WeakMap();
+              this.recordedHtml = new WeakMap();
+              this.resizeObserver = new ResizeObserver(
+                this.resizeObserverCallback
               );
             }
 
-            next(() => document.body.classList.add("suspicious-post-detected"));
-          }
+            afterRender() {
+              // Do this super quick whenever rerendering happens,
+              // otherwise we might miss something
+              this.trackElements();
+            }
 
-          this.recordedHeights.set(post, renderedHeight);
-          this.recordedHtml.set(post, postElement.outerHTML);
-        },
-      });
+            trackElements() {
+              this.element
+                .querySelectorAll("article[data-post-id]")
+                .forEach((e) => this.resizeObserver.observe(e));
+            }
+
+            @bind
+            resizeObserverCallback(resizeObserverEntries) {
+              if (this.isDestroying || this.isDestroyed) {
+                return;
+              }
+
+              for (const entry of resizeObserverEntries) {
+                this.trackHeight(entry.target);
+              }
+            }
+
+            trackHeight(post) {
+              const postNumber = post.id.split("_")[1];
+              const topicId = this.get("posts.posts.firstObject.topic.id");
+              const postLink = `${window.location.protocol}//${window.location.hostname}/t/${topicId}/${postNumber}`;
+              const postElement = post.querySelector(".cooked");
+
+              if (!postElement) {
+                return;
+              }
+
+              const renderedHeight = postElement.getBoundingClientRect().height;
+              const oldHeight = this.recordedHeights.get(post);
+
+              if (oldHeight && renderedHeight !== oldHeight) {
+                console.error(
+                  `🕵 Height of ${postLink} has changed after initial render. Was ${oldHeight}, now ${renderedHeight}`
+                );
+
+                const recordedHtml = this.recordedHtml.get(post);
+                if (recordedHtml === postElement.outerHTML) {
+                  console.log("No HTML change, check CSS");
+                } else {
+                  console.log(
+                    `Previous HTML:\n\n${recordedHtml}\n\nCurrent HTML:\n\n${postElement.outerHTML}`
+                  );
+                }
+
+                next(() =>
+                  document.body.classList.add("suspicious-post-detected")
+                );
+              }
+
+              this.recordedHeights.set(post, renderedHeight);
+              this.recordedHtml.set(post, postElement.outerHTML);
+            }
+          }
+      );
 
       api.onPageChange(() => {
         document.body.classList.remove("suspicious-post-detected");


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely